### PR TITLE
write correct value to native input node on visibility toggle

### DIFF
--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -43,7 +43,7 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
   }
   set value(fileInput: FileInput | null) {
     if (fileInput) {
-      this.writeValue(fileInput.files);
+      this.writeValue(fileInput);
       this.stateChanges.next();
     }
   }
@@ -124,16 +124,8 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
   private _onChange = (_: any) => {};
   private _onTouched = () => {};
 
-  writeValue(obj: File[] | FileInput): void {
-    let data: File[];
-
-    if(obj instanceof FileInput) {
-      data = obj.files;
-    } else {
-      data = obj;
-    }
-
-    this._renderer.setProperty(this._elementRef.nativeElement, 'value', data);
+  writeValue(obj: FileInput): void {
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', obj.files);
   }
 
   registerOnChange(fn: (_: any) => void): void {

--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -122,7 +122,7 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
   }
 
   private _onChange = (_: any) => {};
-  private _onTouched = () => {}; 
+  private _onTouched = () => {};
 
   writeValue(obj: File[] | FileInput): void {
     let data: File[];

--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -122,10 +122,18 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
   }
 
   private _onChange = (_: any) => {};
-  private _onTouched = () => {};
+  private _onTouched = () => {}; 
 
-  writeValue(obj: any): void {
-    this._renderer.setProperty(this._elementRef.nativeElement, 'value', obj);
+  writeValue(obj: File[] | FileInput): void {
+    let data: File[];
+
+    if(obj instanceof FileInput) {
+      data = obj.files;
+    } else {
+      data = obj;
+    }
+
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', data);
   }
 
   registerOnChange(fn: (_: any) => void): void {


### PR DESCRIPTION
When input visibility is manipulated by angular renderer, for example hide/show using *ngIf, it will write to the native `HTMLInputElement.value` the `FileInput` object from the `@Input() value` instead of the array of files.

The PR will fix the issue by verifying the type of object before assigning the to the native input value.
