### PR TITLE
Add clear of native input element

### DIFF
--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -153,6 +153,7 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
       event.stopPropagation();
     }
     this.value = new FileInput([]);
+    this._elementRef.nativeElement.querySelector('input').value = null;
     this._onChange(this.value);
   }
 


### PR DESCRIPTION
This prevents the bug of: select a file, click on 'clear' and you cannot select that file again. You have to select another file or click on 'cancel' button in the popup