### PR TITLE
feat: Support for ErrorStateMatcher

### DIFF
--- a/apps/demo/src/app/app.component.html
+++ b/apps/demo/src/app/app.component.html
@@ -80,6 +80,15 @@
       <mat-icon matSuffix>folder</mat-icon>
     </mat-form-field>
 
+    <h2>Input with custom ErrorStateMatcher</h2>
+
+    <app-code-sample [code]="errorStateTs"></app-code-sample>
+    <app-code-sample [code]="errorState"></app-code-sample>
+
+    <mat-form-field>
+      <ngx-mat-file-input formControlName="errorStateFile" placeholder="Shows error for PDF" [errorStateMatcher]="errorStateMatcher"></ngx-mat-file-input>
+    </mat-form-field>
+
     <h2>ByteFormat pipe</h2>
 
     <app-code-sample [code]="bytePipe"></app-code-sample>

--- a/apps/demo/src/app/app.component.html
+++ b/apps/demo/src/app/app.component.html
@@ -81,6 +81,9 @@
     </mat-form-field>
 
     <h2>Input with custom ErrorStateMatcher</h2>
+    <p>An ErrorStateMatcher defines, when a control displays the error state. A custom ErrorStateMatcher can for example be used to display validations on untouched controls.
+      ErrorStateMatchers can either be defined globally or for single controls (seen in the following example).
+    </p>
 
     <app-code-sample [code]="errorStateTs"></app-code-sample>
     <app-code-sample [code]="errorState"></app-code-sample>

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -3,7 +3,9 @@ import { FormGroup, FormBuilder, Validators, FormControl, NgForm, FormGroupDirec
 import { FileValidator } from 'ngx-material-file-input';
 import { ErrorStateMatcher } from '@angular/material';
 
-
+/**
+* Shows error state on the file-input if a pdf-file is selected.
+*/
 class ExampleErrorStateMatcher implements ErrorStateMatcher {
   public isErrorState(control: FormControl, _: NgForm | FormGroupDirective): boolean {
     return (control && control.value && control.value._fileNames && control.value._fileNames.endsWith('pdf'));

--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -1,6 +1,14 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormControl, NgForm, FormGroupDirective } from '@angular/forms';
 import { FileValidator } from 'ngx-material-file-input';
+import { ErrorStateMatcher } from '@angular/material';
+
+
+class ExampleErrorStateMatcher implements ErrorStateMatcher {
+  public isErrorState(control: FormControl, _: NgForm | FormGroupDirective): boolean {
+    return (control && control.value && control.value._fileNames && control.value._fileNames.endsWith('pdf'));
+  }
+}
 
 @Component({
   selector: 'app-root',
@@ -8,6 +16,7 @@ import { FileValidator } from 'ngx-material-file-input';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements OnInit {
+  errorStateMatcher = new ExampleErrorStateMatcher();
   formDoc: FormGroup;
 
   // 100 MB
@@ -22,7 +31,8 @@ export class AppComponent implements OnInit {
       acceptfile: [],
       requiredfile: [{ value: undefined, disabled: false }, [Validators.required, FileValidator.maxContentSize(this.maxSize)]],
       disabledfile: [{ value: undefined, disabled: true }],
-      multiplefile: [{ value: undefined, disabled: false }]
+      multiplefile: [{ value: undefined, disabled: false }],
+      errorStateFile: []
     });
   }
 
@@ -97,5 +107,21 @@ export class AppComponent implements OnInit {
 
   get bytePipe() {
     return `<p>A file size of {{ maxSize }} gives a human readable size of {{ maxSize | byteFormat }}</p>`;
+  }
+
+  get errorStateTs() {
+    return `class ExampleErrorStateMatcher implements ErrorStateMatcher {
+      public isErrorState(control: FormControl, _: NgForm | FormGroupDirective): boolean {
+        return
+          (control && control.value && control.value._fileNames && control.value._fileNames.endsWith('pdf'));
+      }
+    }`;
+  }
+  get errorState() {
+    return `<mat-form-field>
+      <ngx-mat-file-input formControlName="errorStateFile" placeholder="Shows error for PDF"
+        [errorStateMatcher]="errorStateMatcher">
+      </ngx-mat-file-input>
+    </mat-form-field>`;
   }
 }

--- a/libs/material-file-input/src/lib/file-input/file-input-mixin.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input-mixin.ts
@@ -1,0 +1,19 @@
+import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
+import { CanUpdateErrorStateCtor, ErrorStateMatcher, mixinErrorState } from '@angular/material';
+
+// Boilerplate for applying mixins to FileInput
+/** @docs-private */
+export class FileInputBase {
+  constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
+      public _parentForm: NgForm,
+      public _parentFormGroup: FormGroupDirective,
+      public ngControl: NgControl) { }
+}
+
+/**
+ * Allows to use a custom ErrorStateMatcher with the file-input component
+ */
+export const FileInputMixinBase:
+  CanUpdateErrorStateCtor &
+  typeof FileInputBase =
+  mixinErrorState(FileInputBase);

--- a/libs/material-file-input/src/lib/file-input/file-input.component.spec.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.spec.ts
@@ -1,9 +1,9 @@
-import { ReactiveFormsModule, FormsModule, NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
-import { MatInputModule, MatButtonModule, MatIconModule, MatFormFieldModule } from '@angular/material';
-import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormsModule, NG_VALUE_ACCESSOR, NgControl, ReactiveFormsModule, FormControl, FormGroupDirective, NgForm } from '@angular/forms';
+import { ErrorStateMatcher, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule } from '@angular/material';
 
-import { FileInputComponent } from './file-input.component';
 import { FileInput } from '../model/file-input.model';
+import { FileInputComponent } from './file-input.component';
 
 // function createComponent<T>(component: Type<T>,
 //   providers: Provider[] = [],
@@ -29,6 +29,18 @@ import { FileInput } from '../model/file-input.model';
 // return TestBed.createComponent<T>(component);
 // }
 
+class FileInputSpecErrorStateMatcher implements ErrorStateMatcher {
+  public isErrorState(control: FormControl | null, _: FormGroupDirective | NgForm | null): boolean {
+    return !!(control && control.errors !== null && control.touched);
+  }
+}
+
+class OverrideErrorStateMatcher implements ErrorStateMatcher {
+  public isErrorState(control: FormControl | null, _: FormGroupDirective | NgForm | null): boolean {
+    return !!(control && control.errors && control.errors.length === 2);
+  }
+}
+
 describe('FileInputComponent', () => {
   let component: FileInputComponent;
   let fixture: ComponentFixture<FileInputComponent>;
@@ -46,7 +58,7 @@ describe('FileInputComponent', () => {
           MatButtonModule,
           MatIconModule
         ],
-        providers: [{ provide: NgControl, useValue: NG_VALUE_ACCESSOR }]
+        providers: [{ provide: NgControl, useValue: NG_VALUE_ACCESSOR }, { provide: ErrorStateMatcher, useClass: FileInputSpecErrorStateMatcher }]
       }).compileComponents();
     })
   );
@@ -150,5 +162,41 @@ describe('FileInputComponent', () => {
     spyOn(component, 'open').and.stub();
     fixture.debugElement.nativeElement.click();
     expect(component.open).toHaveBeenCalled();
+  });
+
+  it('should recognize all errorstate changes', () => {
+    spyOn(component.stateChanges, 'next');
+    component.ngControl = <any>{ control: <any>{ errors: null, touched: false } };
+    expect(component.errorState).toBeFalsy();
+    expect(component.stateChanges.next).not.toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(component.errorState).toBeFalsy();
+    expect(component.stateChanges.next).not.toHaveBeenCalled();
+    component.ngControl = <any>{ control: <any>{ errors: ['some error'], touched: true } };
+
+    expect(component.stateChanges.next).not.toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(component.errorState).toBeTruthy();
+    expect(component.stateChanges.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use input ErrorStateMatcher over provided', () => {
+    component.ngControl = <any>{ control: <any>{ errors: ['some error'], touched: true } };
+
+    fixture.detectChanges();
+    expect(component.errorState).toBeTruthy();
+
+    component.errorStateMatcher = new OverrideErrorStateMatcher();
+    expect(component.errorState).toBeTruthy();
+
+    fixture.detectChanges();
+    expect(component.errorState).toBeFalsy();
+    component.ngControl = <any>{ control: <any>{ errors: ['some error', 'another error'] } };
+    expect(component.errorState).toBeFalsy();
+
+    fixture.detectChanges();
+    expect(component.errorState).toBeTruthy();
   });
 });

--- a/libs/material-file-input/src/lib/file-input/file-input.component.spec.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.spec.ts
@@ -29,12 +29,20 @@ import { FileInputComponent } from './file-input.component';
 // return TestBed.createComponent<T>(component);
 // }
 
+/**
+* Shows error state on a control if it is touched and has any error.
+* Used as global ErrorStateMatcher for all tests.
+*/
 class FileInputSpecErrorStateMatcher implements ErrorStateMatcher {
   public isErrorState(control: FormControl | null, _: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.errors !== null && control.touched);
   }
 }
 
+/**
+* Shows error state on a control with exactly two validation errors.
+* Used to change the ErrorStateMatcher of a single component.
+*/
 class OverrideErrorStateMatcher implements ErrorStateMatcher {
   public isErrorState(control: FormControl | null, _: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.errors && control.errors.length === 2);

--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -1,23 +1,11 @@
 import { Component, OnInit, Input, ElementRef, OnDestroy, HostBinding, Renderer2, HostListener, Optional, Self, DoCheck } from '@angular/core';
 import { ControlValueAccessor, NgControl, NgForm, FormGroupDirective } from '@angular/forms';
-import { MatFormFieldControl, ErrorStateMatcher, CanUpdateErrorStateCtor, mixinErrorState } from '@angular/material';
+import { MatFormFieldControl, ErrorStateMatcher } from '@angular/material';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 import { FileInput } from '../model/file-input.model';
-
-// Boilerplate for applying mixins to FileInput
-/** @docs-private */
-export class FileInputBase {
-  constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
-      public _parentForm: NgForm,
-      public _parentFormGroup: FormGroupDirective,
-      public ngControl: NgControl) { }
-}
-export const _FileInputMixinBase:
-  CanUpdateErrorStateCtor &
-  typeof FileInputBase =
-  mixinErrorState(FileInputBase);
+import { FileInputMixinBase } from './file-input-mixin';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -26,7 +14,7 @@ export const _FileInputMixinBase:
   styleUrls: ['./file-input.component.css'],
   providers: [{ provide: MatFormFieldControl, useExisting: FileInputComponent }]
 })
-export class FileInputComponent extends _FileInputMixinBase implements MatFormFieldControl<FileInput>, ControlValueAccessor, OnInit, OnDestroy, DoCheck {
+export class FileInputComponent extends FileInputMixinBase implements MatFormFieldControl<FileInput>, ControlValueAccessor, OnInit, OnDestroy, DoCheck {
   static nextId = 0;
 
   focused = false;
@@ -115,15 +103,15 @@ export class FileInputComponent extends _FileInputMixinBase implements MatFormFi
    * @see https://angular.io/api/forms/ControlValueAccessor
    */
   constructor(
-    @Optional()
-    @Self()
-    public ngControl: NgControl,
     private fm: FocusMonitor,
     private _elementRef: ElementRef,
     private _renderer: Renderer2,
-    @Optional() _parentForm: NgForm,
-    @Optional() _parentFormGroup: FormGroupDirective,
-    _defaultErrorStateMatcher: ErrorStateMatcher,
+    public _defaultErrorStateMatcher: ErrorStateMatcher,
+    @Optional()
+    @Self()
+    public ngControl: NgControl,
+    @Optional() public _parentForm: NgForm,
+    @Optional() public _parentFormGroup: FormGroupDirective,
   ) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl)
 

--- a/libs/material-file-input/src/lib/file-input/file-input.component.ts
+++ b/libs/material-file-input/src/lib/file-input/file-input.component.ts
@@ -1,11 +1,23 @@
-import { Component, OnInit, Input, ElementRef, OnDestroy, HostBinding, Renderer2, HostListener, Optional, Self } from '@angular/core';
-import { ControlValueAccessor, NgControl } from '@angular/forms';
-import { MatFormFieldControl } from '@angular/material';
+import { Component, OnInit, Input, ElementRef, OnDestroy, HostBinding, Renderer2, HostListener, Optional, Self, DoCheck } from '@angular/core';
+import { ControlValueAccessor, NgControl, NgForm, FormGroupDirective } from '@angular/forms';
+import { MatFormFieldControl, ErrorStateMatcher, CanUpdateErrorStateCtor, mixinErrorState } from '@angular/material';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { Subject } from 'rxjs';
 
 import { FileInput } from '../model/file-input.model';
+
+// Boilerplate for applying mixins to FileInput
+/** @docs-private */
+export class FileInputBase {
+  constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
+      public _parentForm: NgForm,
+      public _parentFormGroup: FormGroupDirective,
+      public ngControl: NgControl) { }
+}
+export const _FileInputMixinBase:
+  CanUpdateErrorStateCtor &
+  typeof FileInputBase =
+  mixinErrorState(FileInputBase);
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -14,10 +26,9 @@ import { FileInput } from '../model/file-input.model';
   styleUrls: ['./file-input.component.css'],
   providers: [{ provide: MatFormFieldControl, useExisting: FileInputComponent }]
 })
-export class FileInputComponent implements MatFormFieldControl<FileInput>, ControlValueAccessor, OnInit, OnDestroy {
+export class FileInputComponent extends _FileInputMixinBase implements MatFormFieldControl<FileInput>, ControlValueAccessor, OnInit, OnDestroy, DoCheck {
   static nextId = 0;
 
-  stateChanges = new Subject<void>();
   focused = false;
   controlType = 'file-input';
 
@@ -29,6 +40,7 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
   @Input() valuePlaceholder: string;
   @Input() multiple: boolean;
   @Input() accept: string | null = null;
+  @Input() errorStateMatcher: ErrorStateMatcher;
 
   @HostBinding() id = `ngx-mat-file-input-${FileInputComponent.nextId++}`;
   @HostBinding('attr.aria-describedby') describedBy = '';
@@ -91,11 +103,6 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
     this.stateChanges.next();
   }
 
-  @Input()
-  get errorState(): boolean {
-    return this.ngControl.errors !== null && !!this.ngControl.touched;
-  }
-
   onContainerClick(event: MouseEvent) {
     if ((event.target as Element).tagName.toLowerCase() !== 'input' && !this.disabled) {
       this._elementRef.nativeElement.querySelector('input').focus();
@@ -113,8 +120,13 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
     public ngControl: NgControl,
     private fm: FocusMonitor,
     private _elementRef: ElementRef,
-    private _renderer: Renderer2
+    private _renderer: Renderer2,
+    @Optional() _parentForm: NgForm,
+    @Optional() _parentFormGroup: FormGroupDirective,
+    _defaultErrorStateMatcher: ErrorStateMatcher,
   ) {
+    super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl)
+
     if (this.ngControl != null) {
       this.ngControl.valueAccessor = this;
     }
@@ -194,4 +206,14 @@ export class FileInputComponent implements MatFormFieldControl<FileInput>, Contr
     this.stateChanges.complete();
     this.fm.stopMonitoring(this._elementRef.nativeElement);
   }
+
+  ngDoCheck(): void {
+    if (this.ngControl) {
+      // We need to re-evaluate this on every change detection cycle, because there are some
+      // error triggers that we can't subscribe to (e.g. parent form submissions). This means
+      // that whatever logic is in here has to be super lean or we risk destroying the performance.
+      this.updateErrorState();
+    }
+  }
+
 }


### PR DESCRIPTION
We are using a custom ErrorStateMatcher in our application. Without this feature, the error state of this control and all other controls does not match.